### PR TITLE
Allow setting of Jetty Connector accept queue size

### DIFF
--- a/http.rb
+++ b/http.rb
@@ -29,6 +29,9 @@ class LogStash::Inputs::Http < LogStash::Inputs::Base
   # Max form content size in bytes. Set to -1 to disable.
   config :maxFormSize, :validate => :number, :default => 200000
 
+  # Jetty Server Connector acceptQueueSize. 0 uses implementation default.
+  config :acceptQueueSize, :validate => :number, :default => 0
+
   def initialize(*args)
     super(*args)
   end # def initialize
@@ -57,9 +60,9 @@ class LogStash::Inputs::Http < LogStash::Inputs::Base
       when 'GET'
         ka = httpRequest.getHeader('Connection')
         if ka and ka.downcase == 'keep-alive'
-          httpResponse.addHeader('Connection', 'Keep-Alive')
           httpResponse.setStatus(200)
         else
+          httpResponse.addHeader('Connection', 'Keep-Alive')
           httpResponse.setStatus(501)
         end
 
@@ -91,6 +94,8 @@ class LogStash::Inputs::Http < LogStash::Inputs::Base
       'org.eclipse.jetty.server.Request.maxFormContentSize',
       @maxFormSize
     )
+
+    @server.getConnectors()[0].setAcceptQueueSize(@acceptQueueSize)
     
     handler = LogHandler.new
     handler.setupInput(self, output_queue)


### PR DESCRIPTION
Allow setting of Jetty Connector accept queue size. This works in conjunction with OS level sysctls net.core.somaxconn and net.ipv4.tcp_max_syn_backlog.

My understanding, based on the documentation and inspecting the running code, is that Jetty defaults the accept queue size of a Connector to 0, which trickles down to mean that the actual queue size as enforced via Java's ServerSocket will be 50.

http://download.eclipse.org/jetty/stable-9/apidocs/org/eclipse/jetty/server/ServerConnector.html
http://docs.oracle.com/javase/7/docs/api/java/net/ServerSocket.html#ServerSocket%28int%29

The way I'm getting at the Connector here may be a little hacky; I'm not sure (assuming there will be only 1, most notably). I also have almost no experience with Jetty, so while these changes appear to be working (both not blowing up, and actually achieving their purpose), if you are suspicious of what I am doing here you have every right to be.

Note that these changes were branched from master, which still includes the Keep-Alive response header in the wrong place as discussed in the comments of pull request 2.
